### PR TITLE
Data refactor

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -15,13 +15,19 @@ struct Data
     ys::Vector{Float64}  # y values
     es::Vector{Float64}  # y error values
     function Data(L, xs, ys, es)
-
         # sort data by x values
+        @assert length(xs) == length(ys) == length(es)
         perm = sortperm(xs)
-        xs = xs[perm]
-        ys = ys[perm]
-        es = es[perm] .|> abs
-        return new(L, xs, ys, es)
+        xsd = similar(xs)
+        ysd = similar(ys)
+        esd = similar(es)
+        for i in eachindex(perm)
+            p = perm[i]
+            xsd[i] = xs[p]
+            ysd[i] = ys[p]
+            esd[i] = abs(es[p])
+        end
+        return new(L, xsd, ysd, esd)
     end
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -69,14 +69,14 @@ function _unzip_data(xs, ys, es, Ls)
     map((L, x, y, e) -> Data(L, x, y, e), Ls, xs, ys, es)
 end
 
-function unzip_data(xs::Union{Vector,Matrix}, ys::Union{Vector,Matrix}, Ls::Vector{Int})
+function unzip_data(xs::Union{Vector,Matrix}, ys::Union{Vector,Matrix}, Ls::Vector{<:Integer})
     Lcount = length(Ls)
     xs_reordered = _unzip_data_aux(xs, Lcount)
     ys_reordered = _unzip_data_aux(ys, Lcount)
     _unzip_data(xs_reordered, ys_reordered, Ls)
 end
 
-function unzip_data(xs::Union{Vector,Matrix}, ys::Union{Vector,Matrix}, es::Union{Vector,Matrix}, Ls::Vector{Int})
+function unzip_data(xs::Union{Vector,Matrix}, ys::Union{Vector,Matrix}, es::Union{Vector,Matrix}, Ls::Vector{<:Integer})
     Lcount = length(Ls)
     xs_reordered = _unzip_data_aux(xs, Lcount)
     ys_reordered = _unzip_data_aux(ys, Lcount)


### PR DESCRIPTION
Simplify the code necessary for unzipping various input data formats, to avoid code duplication. Since the current approach treats the `xs` data and `ys` data similarly, this also allows for inputs where `ys` is a constant vector for all systems `L` which was not previously possible.